### PR TITLE
Because we export requirements.txt with hashes we don't need to resolve them with pip

### DIFF
--- a/hooks/check_uv_lock_vulnerabilities.py
+++ b/hooks/check_uv_lock_vulnerabilities.py
@@ -29,7 +29,7 @@ def check_vulnerabilities():
                         f.write(line)
 
             # Run pip-audit
-            sys.argv = ["pip-audit", "-r", req_file_path]
+            sys.argv = ["pip-audit", "-r", req_file_path, "--disable-pip", "--require-hashes"]
             try:
                 audit()
             except SystemExit as e:


### PR DESCRIPTION
This makes it quite a lot faster.

On the Beast on a warm cache `v1.0.0` vs `v1.0.1`:
```console
erik@thebeast:~/git/cookiecutter-template$ rm .git/.pre-commit-check-uv-lock-vulnerabilities-daily-last-run
erik@thebeast:~/git/cookiecutter-template$ time uvx pre-commit run check-uv-lock-vulnerabilities-daily --all-files
Check uv.lock for vulnerabilities (only runs if last successful run was more than 24 hours ago).......................Passed

real    0m3.680s
user    0m2.708s
sys     0m0.360s
erik@thebeast:~/git/cookiecutter-template$ rm .git/.pre-commit-check-uv-lock-vulnerabilities-daily-last-run 
erik@thebeast:~/git/cookiecutter-template$ time uvx pre-commit run check-uv-lock-vulnerabilities-daily --all-files
Check uv.lock for vulnerabilities (only runs if last successful run was more than 24 hours ago).......................Passed

real    0m0.506s
user    0m0.390s
sys     0m0.116s
```

Windows `v1.0.1`:
```console
Erik Wouters@HP_Erik MINGW64 ~/git/ai-recommender-api (new-pre-commit-hooks)
$ rm .git/.pre-commit-check-uv-lock-vulnerabilities-daily-last-run

Erik Wouters@HP_Erik MINGW64 ~/git/ai-recommender-api (new-pre-commit-hooks)
$ time uvx pre-commit run check-uv-lock-vulnerabilities-daily --all-files
Check uv.lock for vulnerabilities (only runs if last successful run was more than 24 hours ago).......................Passed                                     

real    0m1.720s
user    0m0.030s
sys     0m0.091s
```