### PR TITLE
Support ignores in pyproject.toml

### DIFF
--- a/hooks/check_uv_lock_vulnerabilities.py
+++ b/hooks/check_uv_lock_vulnerabilities.py
@@ -1,11 +1,11 @@
-import subprocess
-import tempfile
 import os
+import subprocess
 import sys
+import tempfile
 from pip_audit._cli import audit
 
 
-def check_vulnerabilities():
+def check_vulnerabilities() -> int | str | None:
     # Create a temporary requirements file
     with tempfile.NamedTemporaryFile(
         mode="w+", suffix=".txt", delete=False

--- a/hooks/check_uv_lock_vulnerabilities.py
+++ b/hooks/check_uv_lock_vulnerabilities.py
@@ -24,7 +24,7 @@ def check_vulnerabilities() -> int | str | None:
         try:
             # Export requirements using uv
             subprocess.run(
-                ["uv", "export", "--format=requirements-txt"],
+                ["uv", "export", "--format=requirements-txt", "--all-groups", "--locked"],
                 stdout=req_file,
                 check=True,
             )

--- a/hooks/check_uv_lock_vulnerabilities.py
+++ b/hooks/check_uv_lock_vulnerabilities.py
@@ -3,8 +3,8 @@ import subprocess
 import sys
 import tempfile
 import tomllib
-from pip_audit._cli import audit
 
+from pip_audit._cli import audit
 
 try:
     with open("pyproject.toml", "rb") as f:
@@ -24,19 +24,18 @@ def check_vulnerabilities() -> int | str | None:
         try:
             # Export requirements using uv
             subprocess.run(
-                ["uv", "export", "--format=requirements-txt", "--all-groups", "--locked"],
+                [
+                    "uv",
+                    "export",
+                    "--format=requirements-txt",
+                    "--all-groups",
+                    "--locked",
+                    "--no-emit-local",
+                ],
                 stdout=req_file,
                 check=True,
             )
             req_file.flush()
-
-            # Remove '-e .' if it exists
-            with open(req_file_path, "r") as f:
-                lines = f.readlines()
-            with open(req_file_path, "w") as f:
-                for line in lines:
-                    if line.strip() != "-e .":
-                        f.write(line)
 
             # Build pip-audit arguments
             args = [


### PR DESCRIPTION
# Summary

This PR adds support for specifying vulnerability ignore rules in pyproject.toml under the [tool.pip-audit] section.
This allows developers to centrally manage known or intentionally ignored vulnerabilities without modifying CI scripts or command-line arguments.

# Example Usage

You can now define ignored vulnerability IDs like this:

```
[tool.pip-audit]
ignore-vuln = [
  "PYSEC-2023-45",
  "GHSA-xxxx-yyyy-zzzz",
]
```

These entries will be automatically passed to pip-audit as `--ignore-vuln` flags when running the pre-commit hook (check_uv_lock_vulnerabilities.py).

The vulnerability IDs you may want to add an exception for can be obtained from the output of pip-audit.